### PR TITLE
Use alternate method for  CREATE UNIQUE INDEX IF NOT EXISTS statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "secp256k1": "secp256k1/js"
   },
   "dependencies": {
-    "byteballcore": "git+https://github.com/afxok/byteballcore.git",
+    "byteballcore": "^0.2.1",
     "headless-byteball": "git+https://github.com/byteball/headless-byteball.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "secp256k1": "secp256k1/js"
   },
   "dependencies": {
-    "byteballcore": "^0.2.1",
+    "byteballcore": "git+https://github.com/afxok/byteballcore.git",
     "headless-byteball": "git+https://github.com/byteball/headless-byteball.git"
   }
 }

--- a/start.js
+++ b/start.js
@@ -230,8 +230,8 @@ db.query(
         WHERE table_schema = 'byteball' AND table_name = 'headers_commission_outputs' AND index_name LIKE 'hcobyAddressSpentMci'), \n\
     'SELECT ''index hcobyAddressSpentMci exists'' _______;', \n\
     'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)') into @a; \n\
-    PREPARE stmt1 FROM @a;
-    EXECUTE stmt1;
+    PREPARE stmt1 FROM @a; \n\
+    EXECUTE stmt1; \n\
     DEALLOCATE PREPARE stmt1;");
 
 db.query(
@@ -241,8 +241,8 @@ db.query(
         WHERE table_schema = 'byteball' AND table_name = 'witnessing_outputs' AND index_name LIKE 'byWitnessAddressSpentMci'), \n\
     'SELECT ''index byWitnessAddressSpentMci exists'' _______;', \n\
     'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)') into @a; \n\
-    PREPARE stmt1 FROM @a;
-    EXECUTE stmt1;
+    PREPARE stmt1 FROM @a; \n\
+    EXECUTE stmt1; \n\
     DEALLOCATE PREPARE stmt1;");
 
 

--- a/start.js
+++ b/start.js
@@ -223,8 +223,32 @@ function createOptimalOutputs(handleOutputs){
 
 
 
-db.query("CREATE UNIQUE INDEX IF NOT EXISTS hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)");
-db.query("CREATE UNIQUE INDEX IF NOT EXISTS byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)");
+db.query(
+    "SELECT IF (EXISTS( \n\
+        SELECT DISTINCT index_name \n\
+        FROM information_schema.statistics \n\
+        WHERE table_schema = 'byteball' AND table_name = 'headers_commission_outputs' AND index_name LIKE 'hcobyAddressSpentMci'), \n\
+    'SELECT ''index hcobyAddressSpentMci exists'' _______;', \n\
+    'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)') into @a; \n\
+    PREPARE stmt1 FROM @a;
+    EXECUTE stmt1;
+    DEALLOCATE PREPARE stmt1;");
+
+db.query(
+    "SELECT IF (EXISTS( \n\
+        SELECT DISTINCT index_name \n\
+        FROM information_schema.statistics \n\
+        WHERE table_schema = 'byteball' AND table_name = 'witnessing_outputs' AND index_name LIKE 'byWitnessAddressSpentMci'), \n\
+    'SELECT ''index byWitnessAddressSpentMci exists'' _______;', \n\
+    'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)') into @a; \n\
+    PREPARE stmt1 FROM @a;
+    EXECUTE stmt1;
+    DEALLOCATE PREPARE stmt1;");
+
+
+
+
+
 
 eventBus.on('headless_wallet_ready', function(){
 	if (!conf.admin_email || !conf.from_email){

--- a/start.js
+++ b/start.js
@@ -221,29 +221,27 @@ function createOptimalOutputs(handleOutputs){
 	});
 }
 
-
-
 db.query(
     "SELECT IF (EXISTS( \n\
         SELECT DISTINCT index_name \n\
         FROM information_schema.statistics \n\
         WHERE table_schema = 'byteball' AND table_name = 'headers_commission_outputs' AND index_name LIKE 'hcobyAddressSpentMci'), \n\
-    'SELECT ''index hcobyAddressSpentMci exists'' _______;', \n\
-    'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)') into @a; \n\
-    PREPARE stmt1 FROM @a; \n\
-    EXECUTE stmt1; \n\
-    DEALLOCATE PREPARE stmt1;");
+    'SELECT ''index hcobyAddressSpentMci exists''as _______;', \n\
+    'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)') into @a");
+db.query("PREPARE stmt1 FROM @a");
+db.query("EXECUTE stmt1");
+db.query("DEALLOCATE PREPARE stmt1");
 
 db.query(
     "SELECT IF (EXISTS( \n\
         SELECT DISTINCT index_name \n\
         FROM information_schema.statistics \n\
         WHERE table_schema = 'byteball' AND table_name = 'witnessing_outputs' AND index_name LIKE 'byWitnessAddressSpentMci'), \n\
-    'SELECT ''index byWitnessAddressSpentMci exists'' _______;', \n\
-    'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)') into @a; \n\
-    PREPARE stmt1 FROM @a; \n\
-    EXECUTE stmt1; \n\
-    DEALLOCATE PREPARE stmt1;");
+    'SELECT ''index byWitnessAddressSpentMci exists'' as _______;', \n\
+    'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)') into @a");
+db.query("PREPARE stmt1 FROM @a");
+db.query("EXECUTE stmt1");
+db.query("DEALLOCATE PREPARE stmt1");
 
 
 

--- a/start.js
+++ b/start.js
@@ -226,22 +226,24 @@ db.query(
         SELECT DISTINCT index_name \n\
         FROM information_schema.statistics \n\
         WHERE table_schema = 'byteball' AND table_name = 'headers_commission_outputs' AND index_name LIKE 'hcobyAddressSpentMci'), \n\
-    'SELECT ''index hcobyAddressSpentMci exists''as _______;', \n\
-    'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)') into @a");
-db.query("PREPARE stmt1 FROM @a");
-db.query("EXECUTE stmt1");
-db.query("DEALLOCATE PREPARE stmt1");
+    'SELECT ''index hcobyAddressSpentMci exists''', \n\
+    'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)')",
+    function(rows) {
+        console.log(JSON.stringify(rows[0]);
+        db.query(rows[0]);
+    });
 
 db.query(
     "SELECT IF (EXISTS( \n\
         SELECT DISTINCT index_name \n\
         FROM information_schema.statistics \n\
         WHERE table_schema = 'byteball' AND table_name = 'witnessing_outputs' AND index_name LIKE 'byWitnessAddressSpentMci'), \n\
-    'SELECT ''index byWitnessAddressSpentMci exists'' as _______;', \n\
-    'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)') into @a");
-db.query("PREPARE stmt1 FROM @a");
-db.query("EXECUTE stmt1");
-db.query("DEALLOCATE PREPARE stmt1");
+    'SELECT ''index byWitnessAddressSpentMci exists''', \n\
+    'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)')",
+    function(rows) {
+        console.log(JSON.stringify(rows[0]);
+        db.query(rows[0]);
+    });
 
 
 

--- a/start.js
+++ b/start.js
@@ -229,7 +229,6 @@ db.query(
     'SELECT ''index hcobyAddressSpentMci exists''', \n\
     'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)')) AS stmt",
     function(rows) {
-        console.log(JSON.stringify(rows[0].stmt));
         db.query(rows[0].stmt);
     });
 
@@ -243,7 +242,6 @@ db.query(
     'SELECT ''index byWitnessAddressSpentMci exists''', \n\
     'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)')) AS stmt",
     function(rows) {
-        console.log(JSON.stringify(rows[0].stmt));
         db.query(rows[0].stmt);
     });
 

--- a/start.js
+++ b/start.js
@@ -229,7 +229,7 @@ db.query(
     'SELECT ''index hcobyAddressSpentMci exists''', \n\
     'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)')",
     function(rows) {
-        console.log(JSON.stringify(rows[0]);
+        console.log(JSON.stringify(rows[0]));
         db.query(rows[0]);
     });
 
@@ -241,7 +241,7 @@ db.query(
     'SELECT ''index byWitnessAddressSpentMci exists''', \n\
     'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)')",
     function(rows) {
-        console.log(JSON.stringify(rows[0]);
+        console.log(JSON.stringify(rows[0]));
         db.query(rows[0]);
     });
 

--- a/start.js
+++ b/start.js
@@ -222,27 +222,29 @@ function createOptimalOutputs(handleOutputs){
 }
 
 db.query(
-    "SELECT IF (EXISTS( \n\
+    "SELECT (IF (EXISTS( \n\
         SELECT DISTINCT index_name \n\
         FROM information_schema.statistics \n\
         WHERE table_schema = 'byteball' AND table_name = 'headers_commission_outputs' AND index_name LIKE 'hcobyAddressSpentMci'), \n\
     'SELECT ''index hcobyAddressSpentMci exists''', \n\
-    'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)')",
+    'CREATE INDEX hcobyAddressSpentMci ON headers_commission_outputs(address, is_spent, main_chain_index)')) AS stmt",
     function(rows) {
-        console.log(JSON.stringify(rows[0]));
-        db.query(rows[0]);
+        console.log(JSON.stringify(rows[0].stmt));
+        db.query(rows[0].stmt);
     });
 
 db.query(
-    "SELECT IF (EXISTS( \n\
-        SELECT DISTINCT index_name \n\
-        FROM information_schema.statistics \n\
-        WHERE table_schema = 'byteball' AND table_name = 'witnessing_outputs' AND index_name LIKE 'byWitnessAddressSpentMci'), \n\
+    "SELECT (\n\
+        IF (EXISTS( \n\
+    	    SELECT DISTINCT index_name \n\
+    	    FROM information_schema.statistics \n\
+    	    WHERE table_schema = 'byteball' AND table_name = 'witnessing_outputs' AND index_name LIKE 'byWitnessAddressSpentMci' \n\
+        ), \n\
     'SELECT ''index byWitnessAddressSpentMci exists''', \n\
-    'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)')",
+    'CREATE INDEX byWitnessAddressSpentMci ON witnessing_outputs(address, is_spent, main_chain_index)')) AS stmt",
     function(rows) {
-        console.log(JSON.stringify(rows[0]));
-        db.query(rows[0]);
+        console.log(JSON.stringify(rows[0].stmt));
+        db.query(rows[0].stmt);
     });
 
 


### PR DESCRIPTION
I have a new byteball setup that I'm running with MySQL 5.7 and CREATE UNIQUE INDEX IF NOT EXISTS statements are not supported. As far as I can tell they're not supported on any earlier MySQL version either. This fix uses an alternate method to accomplish the same thing.